### PR TITLE
*: add txnkv register test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,16 @@ all: build
 
 build: chaos verifier
 
-chaos: rawkv tidb
+chaos: rawkv tidb txnkv
 
 tidb:
 	go build -o bin/chaos-tidb cmd/tidb/main.go
 
 rawkv:
 	go build -o bin/chaos-rawkv cmd/rawkv/main.go
+
+txnkv:
+	go build -o bin/chaos-txnkv cmd/txnkv/main.go
 
 verifier:
 	go build -o bin/chaos-verifier cmd/verifier/main.go

--- a/cmd/txnkv/main.go
+++ b/cmd/txnkv/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"time"
+
+	"github.com/siddontang/chaos/cmd/util"
+	"github.com/siddontang/chaos/db/txnkv"
+	"github.com/siddontang/chaos/pkg/control"
+	"github.com/siddontang/chaos/pkg/core"
+)
+
+var (
+	requestCount = flag.Int("request-count", 500, "client test request count")
+	runTime      = flag.Duration("run-time", 10*time.Minute, "client test run time")
+	clientCase   = flag.String("case", "register", "client test case, like bank,multi_bank")
+	historyFile  = flag.String("history", "./history.log", "history file")
+	nemesises    = flag.String("nemesis", "", "nemesis, seperated by name, like random_kill,all_kill")
+	verifyNames  = flag.String("verifiers", "", "verifier names, seperate by comma, txnkv_register")
+)
+
+func main() {
+	flag.Parse()
+
+	cfg := control.Config{
+		DB:           "txnkv",
+		RequestCount: *requestCount,
+		RunTime:      *runTime,
+		History:      *historyFile,
+	}
+
+	var creator core.ClientCreator
+	switch *clientCase {
+	case "register":
+		creator = txnkv.RegisterClientCreator{}
+	default:
+		log.Fatalf("invalid client test case %s", *clientCase)
+	}
+
+	suit := util.Suit{
+		Config:        cfg,
+		ClientCreator: creator,
+		VerifyNames:   *verifyNames,
+		Nemesises:     *nemesises,
+	}
+	suit.Run()
+}

--- a/db/txnkv/db.go
+++ b/db/txnkv/db.go
@@ -1,0 +1,23 @@
+package txnkv
+
+import (
+	"github.com/siddontang/chaos/db/cluster"
+	"github.com/siddontang/chaos/pkg/core"
+)
+
+// db is the transactional KV database.
+type db struct {
+	cluster.Cluster
+}
+
+// Name returns the unique name for the database
+func (db *db) Name() string {
+	return "txnkv"
+}
+
+func init() {
+	core.RegisterDB(&db{
+		// TxnKV does not use TiDB.
+		cluster.Cluster{IncludeTidb: false},
+	})
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,6 +15,12 @@ for bin in $@; do
         nemeses=( random_kill  )
         verifiers=( register )
         ;;
+    'txnkv' )
+        suit=chaos-txnkv
+        cases=( register )
+        nemeses=( random_kill  )
+        verifiers=( register )
+        ;;
     '--help' )
         HELP=1
         ;;
@@ -30,6 +36,7 @@ if [ "$HELP" ]; then
     echo "usage: $0 [OPTION]"
     echo "  tidb                                                  Chaos test TiDB"
     echo "  rawkv                                                 Chaos test RawKV"
+    echo "  txnkv                                                 Chaos test TxnKV"
     echo "  --help                                                Display this message"
     exit 0
 fi


### PR DESCRIPTION
Add txn kv register test.

Here is an example output:

```
root@control:/go/src/github.com/siddontang/chaos# scripts/test.sh txnkv
run register with nemeses random_kill
2018/07/13 12:48:18 begin to set up database
...
2018/07/13 12:49:00 begin to set up db client for node n4
INFO[0041] [pd] create pd client with endpoints [n5:2379] 
...
INFO[0041] [pd] init cluster id 6577682755455829196     
2018/07/13 12:49:00 begin to run nemesis
2018/07/13 12:49:00 begin to run random_kill nemesis generator
2018/07/13 12:49:00 begin to run command on node n3
2018/07/13 12:49:00 run nemesis kill on n4
2018/07/13 12:49:00 begin to run command on node n1
2018/07/13 12:49:00 begin to run command on node n2
2018/07/13 12:49:00 begin to run command on node n4
2018/07/13 12:49:00 begin to run command on node n5
INFO[0041] [con:0] 2PC clean up done, tid: 401469902728200203 
...
INFO[0042] [con:0] 2PC clean up done, tid: 401469902990344232 
2018/07/13 12:49:01 start database on node n4
2018/07/13 12:49:01 start pd-server on node n4
2018/07/13 12:49:01 run nemesis kill on n4 failed: context canceled
2018/07/13 12:49:01 stop to run nemesis
2018/07/13 12:49:01 begin to tear down client
...
2018/07/13 12:49:01 finish test
use register to check history ./var/history_chaos-txnkv_register_random_kill.log
2018/07/13 12:49:01 begin to check with register_verifier
2018/07/13 12:49:01 begin to verify 2000 events
2018/07/13 12:49:01 register_verifier: history ./var/history_chaos-txnkv_register_random_kill.log is linearizable
```