### PR TITLE
*: add Model, Operation and Checker

### DIFF
--- a/Porcupine-LICENSE
+++ b/Porcupine-LICENSE
@@ -1,0 +1,1 @@
+vendor/github.com/anishathalye/porcupine/LICENSE.md

--- a/cmd/rawkv/main.go
+++ b/cmd/rawkv/main.go
@@ -17,7 +17,6 @@ var (
 	clientCase   = flag.String("case", "register", "client test case, like bank,multi_bank")
 	historyFile  = flag.String("history", "./history.log", "history file")
 	nemesises    = flag.String("nemesis", "", "nemesis, seperated by name, like random_kill,all_kill")
-	verifyNames  = flag.String("verifiers", "", "verifier names, seperate by comma, register")
 )
 
 func main() {
@@ -41,7 +40,7 @@ func main() {
 	suit := util.Suit{
 		Config:        cfg,
 		ClientCreator: creator,
-		VerifyNames:   *verifyNames,
+		ModelNames:    "register",
 		Nemesises:     *nemesises,
 	}
 	suit.Run()

--- a/cmd/tidb/main.go
+++ b/cmd/tidb/main.go
@@ -17,7 +17,7 @@ var (
 	clientCase   = flag.String("case", "bank", "client test case, like bank,multi_bank")
 	historyFile  = flag.String("history", "./history.log", "history file")
 	nemesises    = flag.String("nemesis", "", "nemesis, seperated by name, like random_kill,all_kill")
-	verifyNames  = flag.String("verifiers", "", "verifier names, seperate by comma, tidb_bank,tidb_bank_tso")
+	modelNames   = flag.String("models", "", "model names, seperate by comma, tidb_bank,tidb_bank_tso")
 )
 
 func main() {
@@ -43,7 +43,7 @@ func main() {
 	suit := util.Suit{
 		Config:        cfg,
 		ClientCreator: creator,
-		VerifyNames:   *verifyNames,
+		ModelNames:    *modelNames,
 		Nemesises:     *nemesises,
 	}
 	suit.Run()

--- a/cmd/txnkv/main.go
+++ b/cmd/txnkv/main.go
@@ -17,7 +17,6 @@ var (
 	clientCase   = flag.String("case", "register", "client test case, like bank,multi_bank")
 	historyFile  = flag.String("history", "./history.log", "history file")
 	nemesises    = flag.String("nemesis", "", "nemesis, seperated by name, like random_kill,all_kill")
-	verifyNames  = flag.String("verifiers", "", "verifier names, seperate by comma, txnkv_register")
 )
 
 func main() {
@@ -41,7 +40,7 @@ func main() {
 	suit := util.Suit{
 		Config:        cfg,
 		ClientCreator: creator,
-		VerifyNames:   *verifyNames,
+		ModelNames:    "register",
 		Nemesises:     *nemesises,
 	}
 	suit.Run()

--- a/cmd/util/suit.go
+++ b/cmd/util/suit.go
@@ -18,8 +18,8 @@ import (
 type Suit struct {
 	control.Config
 	core.ClientCreator
-	// verifier names, seperate by comma.
-	VerifyNames string
+	// model names, seperate by comma.
+	ModelNames string
 	// nemesis, seperated by comma.
 	Nemesises string
 }
@@ -61,5 +61,5 @@ func (suit *Suit) Run() {
 
 	c.Run()
 
-	verify.Verify(ctx, suit.Config.History, suit.VerifyNames)
+	verify.Verify(ctx, suit.Config.History, suit.ModelNames)
 }

--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	historyFile = flag.String("history", "./history.log", "history file")
-	names       = flag.String("names", "", "verifier names, seperate by comma")
+	names       = flag.String("names", "", "model names, seperate by comma")
 	pprofAddr   = flag.String("pprof", "0.0.0.0:6060", "Pprof address")
 )
 

--- a/cmd/verifier/verify/util.go
+++ b/cmd/verifier/verify/util.go
@@ -6,23 +6,32 @@ import (
 	"strings"
 
 	"github.com/siddontang/chaos/db/tidb"
+	"github.com/siddontang/chaos/pkg/check/porcupine"
+	"github.com/siddontang/chaos/pkg/core"
 	"github.com/siddontang/chaos/pkg/history"
 	"github.com/siddontang/chaos/pkg/model"
 )
 
-// Verify creates the verifier from verifer_names and verfies the history file.
-func Verify(ctx context.Context, historyFile string, verfier_names string) {
-	var verifieres []history.Verifier
+type suit struct {
+	checker core.Checker
+	model   core.Model
+	parser  history.RecordParser
+}
 
-	for _, name := range strings.Split(verfier_names, ",") {
-		var verifier history.Verifier
+// Verify creates the verifier from model name and verfies the history file.
+func Verify(ctx context.Context, historyFile string, modelNames string) {
+	var suits []suit
+
+	for _, name := range strings.Split(modelNames, ",") {
+		s := suit{}
 		switch name {
 		case "tidb_bank":
-			verifier = tidb.BankVerifier{}
+			s.model, s.parser, s.checker = tidb.BankModel(), tidb.BankParser(), porcupine.Checker{}
 		case "tidb_bank_tso":
-			verifier = tidb.BankTsoVerifier{}
+			// Actually we can omit BankModel, since BankTsoChecker does not require a Model.
+			s.model, s.parser, s.checker = tidb.BankModel(), tidb.BankParser(), tidb.BankTsoChecker()
 		case "register":
-			verifier = model.RegisterVerifier{}
+			s.model, s.parser, s.checker = model.RegisterModel(), model.RegisterParser(), porcupine.Checker{}
 		case "":
 			continue
 		default:
@@ -30,23 +39,33 @@ func Verify(ctx context.Context, historyFile string, verfier_names string) {
 			continue
 		}
 
-		verifieres = append(verifieres, verifier)
+		suits = append(suits, s)
 	}
 
 	childCtx, cancel := context.WithCancel(ctx)
 
 	go func() {
-		for _, verifier := range verifieres {
-			log.Printf("begin to check with %s", verifier.Name())
-			ok, err := verifier.Verify(historyFile)
+		for _, suit := range suits {
+			log.Printf("begin to check %s with %s", suit.model.Name(), suit.checker.Name())
+			ops, err := history.ReadHistory(historyFile, suit.parser)
+			if err != nil {
+				log.Fatalf("read history failed %v", err)
+			}
+
+			ops, err = history.CompleteOperations(ops, suit.parser)
+			if err != nil {
+				log.Fatalf("complete history failed %v", err)
+			}
+
+			ok, err := suit.checker.Check(suit.model, ops)
 			if err != nil {
 				log.Fatalf("verify history failed %v", err)
 			}
 
 			if !ok {
-				log.Fatalf("%s: history %s is not linearizable", verifier.Name(), historyFile)
+				log.Fatalf("%s: history %s is not linearizable", suit.model.Name(), historyFile)
 			} else {
-				log.Printf("%s: history %s is linearizable", verifier.Name(), historyFile)
+				log.Printf("%s: history %s is linearizable", suit.model.Name(), historyFile)
 			}
 		}
 

--- a/db/tidb/bank_test.go
+++ b/db/tidb/bank_test.go
@@ -11,6 +11,25 @@ func checkTsoEvents(evnets []porcupine.Event) bool {
 	return verifyTsoEvents(tEvents)
 }
 
+func getBankModel(accountNum int) porcupine.Model {
+	m := bank{
+		accountNum: 2,
+	}
+	return porcupine.Model{
+		Init:  m.Init,
+		Step:  m.Step,
+		Equal: m.Equal,
+	}
+}
+
+func newBankEvent(v interface{}, id uint) porcupine.Event {
+	if _, ok := v.(bankRequest); ok {
+		return porcupine.Event{Kind: porcupine.CallEvent, Value: v, Id: id}
+	}
+
+	return porcupine.Event{Kind: porcupine.ReturnEvent, Value: v, Id: id}
+}
+
 func TestBankVerify(t *testing.T) {
 	m := getBankModel(2)
 

--- a/pkg/check/doc.go
+++ b/pkg/check/doc.go
@@ -1,0 +1,3 @@
+// check is the place to put checkers.
+
+package check

--- a/pkg/check/porcupine/porcupine.go
+++ b/pkg/check/porcupine/porcupine.go
@@ -1,0 +1,76 @@
+package porcupine
+
+import (
+	"log"
+
+	"github.com/pkg/errors"
+
+	"github.com/anishathalye/porcupine"
+	"github.com/siddontang/chaos/pkg/core"
+)
+
+// Checker is a linearizability checker powered by Porcupine.
+type Checker struct{}
+
+// Check checks the history of operations meets liearizability or not with model.
+// False means the history is not linearizable.
+func (Checker) Check(m core.Model, ops []core.Operation) (bool, error) {
+	pModel := porcupine.Model{
+		Init:  m.Init,
+		Step:  m.Step,
+		Equal: m.Equal,
+	}
+	events, err := ConvertOperationsToEvents(ops)
+	if err != nil {
+		return false, err
+	}
+	log.Printf("begin to verify %d events", len(events))
+	return porcupine.CheckEvents(pModel, events), nil
+}
+
+// Name is the name of porcupine checker
+func (Checker) Name() string {
+	return "porcupine_checker"
+}
+
+// ConvertOperationsToEvents converts core.Operations to porcupine.Event.
+func ConvertOperationsToEvents(ops []core.Operation) ([]porcupine.Event, error) {
+	if len(ops)%2 != 0 {
+		return nil, errors.New("history is not complete")
+	}
+
+	procID := map[int64]uint{}
+	id := uint(0)
+	events := make([]porcupine.Event, 0, len(ops))
+	for _, op := range ops {
+		if op.Action == core.InvokeOperation {
+			event := porcupine.Event{
+				Kind:  porcupine.CallEvent,
+				Id:    id,
+				Value: op.Data,
+			}
+			events = append(events, event)
+			procID[op.Proc] = id
+			id++
+		} else {
+			if op.Data == nil {
+				continue
+			}
+
+			matchID := procID[op.Proc]
+			delete(procID, op.Proc)
+			event := porcupine.Event{
+				Kind:  porcupine.ReturnEvent,
+				Id:    matchID,
+				Value: op.Data,
+			}
+			events = append(events, event)
+		}
+	}
+
+	if len(procID) != 0 {
+		return nil, errors.New("history is not complete")
+	}
+
+	return events, nil
+}

--- a/pkg/check/porcupine/porcupine_test.go
+++ b/pkg/check/porcupine/porcupine_test.go
@@ -1,0 +1,71 @@
+package porcupine
+
+import (
+	"testing"
+
+	"github.com/siddontang/chaos/pkg/core"
+)
+
+type noopRequest struct {
+	// 0 for read, 1 for write
+	Op    int
+	Value int
+}
+
+type noopResponse struct {
+	Value   int
+	Ok      bool
+	Unknown bool
+}
+
+type noop struct{}
+
+func (noop) Init() interface{} {
+	return 10
+}
+
+func (noop) Step(state interface{}, input interface{}, output interface{}) (bool, interface{}) {
+	st := state.(int)
+	inp := input.(noopRequest)
+	out := output.(noopResponse)
+
+	if inp.Op == 0 {
+		// read
+		ok := out.Unknown || st == out.Value
+		return ok, state
+	}
+
+	// for write
+	return out.Ok || out.Unknown, inp.Value
+}
+
+func (noop) Equal(state1, state2 interface{}) bool {
+	s1 := state1.(int)
+	s2 := state2.(int)
+
+	return s1 == s2
+}
+
+func (noop) Name() string {
+	return "noop"
+}
+
+func TestPorcupineChecker(t *testing.T) {
+	ops := []core.Operation{
+		{core.InvokeOperation, 1, noopRequest{Op: 0}},
+		{core.ReturnOperation, 1, noopResponse{Value: 10}},
+		{core.InvokeOperation, 2, noopRequest{Op: 1, Value: 15}},
+		{core.ReturnOperation, 2, noopResponse{Unknown: true}},
+		{core.InvokeOperation, 3, noopRequest{Op: 0}},
+		{core.ReturnOperation, 3, noopResponse{Value: 15}},
+	}
+
+	var checker Checker
+	ok, err := checker.Check(noop{}, ops)
+	if err != nil {
+		t.Fatalf("verify history failed %v", err)
+	}
+	if !ok {
+		t.Fatal("must be linearizable")
+	}
+}

--- a/pkg/core/checker.go
+++ b/pkg/core/checker.go
@@ -1,0 +1,11 @@
+package core
+
+// Checker checks a history of operations.
+type Checker interface {
+	// Check a series of operations with the given model.
+	// Return false or error if operations do not satisfy the model.
+	Check(m Model, ops []Operation) (bool, error)
+
+	// Name returns the unique name for the checker.
+	Name() string
+}

--- a/pkg/core/model.go
+++ b/pkg/core/model.go
@@ -1,0 +1,31 @@
+package core
+
+// Model specifies the behavior of a data object.
+type Model interface {
+	// Initial state of the data object.
+	Init() interface{}
+
+	// Step function for the data object. Returns whether or not the system
+	// could take this step with the given inputs and outputs and also
+	// returns the new state. This should not mutate the existing state.
+	Step(state interface{}, input interface{}, output interface{}) (bool, interface{})
+
+	// Equality on states.
+	Equal(state1, state2 interface{}) bool
+
+	// Name returns the unique name for the model.
+	Name() string
+}
+
+// Operation action
+const (
+	InvokeOperation = "call"
+	ReturnOperation = "return"
+)
+
+// Operation of a data object.
+type Operation struct {
+	Action string      `json:"action"`
+	Proc   int64       `json:"proc"`
+	Data   interface{} `json:"data"`
+}

--- a/pkg/model/cas_register.go
+++ b/pkg/model/cas_register.go
@@ -3,7 +3,6 @@ package model
 import (
 	"encoding/json"
 
-	"github.com/anishathalye/porcupine"
 	"github.com/siddontang/chaos/pkg/core"
 	"github.com/siddontang/chaos/pkg/history"
 )
@@ -40,40 +39,47 @@ func (r CasRegisterResponse) IsUnknown() bool {
 	return r.Unknown
 }
 
-// CasRegisterModel returns a cas register model
-func CasRegisterModel() porcupine.Model {
-	return porcupine.Model{
-		Init: func() interface{} {
-			return -1
-		},
-		Step: func(state interface{}, input interface{}, output interface{}) (bool, interface{}) {
-			st := state.(int)
-			inp := input.(CasRegisterRequest)
-			out := output.(CasRegisterResponse)
-			if inp.Op == CasRegisterRead {
-				// read
-				ok := (out.Exists == false && st == -1) || (out.Exists == true && st == out.Value) || out.Unknown
-				return ok, state
-			} else if inp.Op == CasRegisterWrite {
-				// write
-				return true, inp.Arg1
-			}
+type casRegister struct{}
 
-			// cas
-			ok := (inp.Arg1 == st && out.Ok) || (inp.Arg1 != st && !out.Ok) || out.Unknown
-			result := st
-			if inp.Arg1 == st {
-				result = inp.Arg2
-			}
-			return ok, result
-		},
+func (casRegister) Init() interface{} {
+	return -1
+}
 
-		Equal: func(state1, state2 interface{}) bool {
-			st1 := state1.(int)
-			st2 := state2.(int)
-			return st1 == st2
-		},
+func (casRegister) Step(state interface{}, input interface{}, output interface{}) (bool, interface{}) {
+	st := state.(int)
+	inp := input.(CasRegisterRequest)
+	out := output.(CasRegisterResponse)
+	if inp.Op == CasRegisterRead {
+		// read
+		ok := (out.Exists == false && st == -1) || (out.Exists == true && st == out.Value) || out.Unknown
+		return ok, state
+	} else if inp.Op == CasRegisterWrite {
+		// write
+		return true, inp.Arg1
 	}
+
+	// cas
+	ok := (inp.Arg1 == st && out.Ok) || (inp.Arg1 != st && !out.Ok) || out.Unknown
+	result := st
+	if inp.Arg1 == st {
+		result = inp.Arg2
+	}
+	return ok, result
+}
+
+func (casRegister) Equal(state1, state2 interface{}) bool {
+	st1 := state1.(int)
+	st2 := state2.(int)
+	return st1 == st2
+}
+
+func (casRegister) Name() string {
+	return "cas_register"
+}
+
+// CasRegisterModel returns a cas register model
+func CasRegisterModel() core.Model {
+	return casRegister{}
 }
 
 type casRegisterParser struct {
@@ -98,16 +104,7 @@ func (p casRegisterParser) OnNoopResponse() interface{} {
 	return CasRegisterResponse{Unknown: true}
 }
 
-// CasRegisterVerifier can verify a cas register history.
-type CasRegisterVerifier struct {
-}
-
-// Verify verifies a cas register history.
-func (CasRegisterVerifier) Verify(historyFile string) (bool, error) {
-	return history.IsLinearizable(historyFile, CasRegisterModel(), casRegisterParser{})
-}
-
-// Name returns the name of the verifier.
-func (CasRegisterVerifier) Name() string {
-	return "cas_register_verifier"
+// CasRegisterParser parses CasRegister history.
+func CasRegisterParser() history.RecordParser {
+	return casRegisterParser{}
 }

--- a/pkg/model/cas_register_test.go
+++ b/pkg/model/cas_register_test.go
@@ -4,7 +4,16 @@ import (
 	"testing"
 
 	"github.com/anishathalye/porcupine"
+	"github.com/siddontang/chaos/pkg/core"
 )
+
+func convertModel(m core.Model) porcupine.Model {
+	return porcupine.Model{
+		Init:  m.Init,
+		Step:  m.Step,
+		Equal: m.Equal,
+	}
+}
 
 func TestCasRegisterModel(t *testing.T) {
 	events := []porcupine.Event{
@@ -19,7 +28,7 @@ func TestCasRegisterModel(t *testing.T) {
 		{Kind: porcupine.ReturnEvent, Value: CasRegisterResponse{Ok: true}, Id: 3},
 		{Kind: porcupine.ReturnEvent, Value: CasRegisterResponse{Value: 200}, Id: 4},
 	}
-	res := porcupine.CheckEvents(CasRegisterModel(), events)
+	res := porcupine.CheckEvents(convertModel(CasRegisterModel()), events)
 	if res != true {
 		t.Fatal("expected operations to be linearizable")
 	}

--- a/pkg/model/register_test.go
+++ b/pkg/model/register_test.go
@@ -17,7 +17,7 @@ func TestRegisterModel(t *testing.T) {
 		{RegisterRequest{RegisterRead, 0}, 25, RegisterResponse{false, 100}, 75},
 		{RegisterRequest{RegisterRead, 0}, 30, RegisterResponse{false, 0}, 60},
 	}
-	res := porcupine.CheckOperations(RegisterModel(), ops)
+	res := porcupine.CheckOperations(convertModel(RegisterModel()), ops)
 	if res != true {
 		t.Fatal("expected operations to be linearizable")
 	}
@@ -31,7 +31,7 @@ func TestRegisterModel(t *testing.T) {
 		{porcupine.ReturnEvent, RegisterResponse{false, 100}, 1},
 		{porcupine.ReturnEvent, RegisterResponse{false, 0}, 0},
 	}
-	res = porcupine.CheckEvents(RegisterModel(), events)
+	res = porcupine.CheckEvents(convertModel(RegisterModel()), events)
 	if res != true {
 		t.Fatal("expected operations to be linearizable")
 	}
@@ -41,7 +41,7 @@ func TestRegisterModel(t *testing.T) {
 		{RegisterRequest{RegisterRead, 0}, 10, RegisterResponse{false, 200}, 30},
 		{RegisterRequest{RegisterRead, 0}, 40, RegisterResponse{false, 0}, 90},
 	}
-	res = porcupine.CheckOperations(RegisterModel(), ops)
+	res = porcupine.CheckOperations(convertModel(RegisterModel()), ops)
 	if res != false {
 		t.Fatal("expected operations to not be linearizable")
 	}
@@ -55,7 +55,7 @@ func TestRegisterModel(t *testing.T) {
 		{porcupine.ReturnEvent, RegisterResponse{false, 0}, 2},
 		{porcupine.ReturnEvent, RegisterResponse{false, 0}, 0},
 	}
-	res = porcupine.CheckEvents(RegisterModel(), events)
+	res = porcupine.CheckEvents(convertModel(RegisterModel()), events)
 	if res != false {
 		t.Fatal("expected operations to not be linearizable")
 	}


### PR DESCRIPTION
Model defines an interface of a data object and Checker
defines an interface of a checker, together they privode an
abstract of linearizability check formwork.

It also decouples Porcupine from Chaos. We can add more checkers
in the future.